### PR TITLE
Change Get-Help cmdlet -Parameter parameter so it accepts string arrays.

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4094,7 +4094,7 @@ param(
     ${Examples},
 
     [Parameter(ParameterSetName='Parameters', Mandatory=$true)]
-    [string]
+    [string[]]
     ${Parameter},
 
     [string[]]

--- a/src/System.Management.Automation/help/HelpCommands.cs
+++ b/src/System.Management.Automation/help/HelpCommands.cs
@@ -157,12 +157,7 @@ namespace Microsoft.PowerShell.Commands
         /// Support WildCard strings as supported by WildcardPattern class.
         /// </remarks>
         [Parameter(ParameterSetName = "Parameters", Mandatory = true)]
-        public string[] Parameter
-        {
-            get => _parameters;
-            set => _parameters = value;
-        }
-        private string[] _parameters;
+        public string[] Parameter { get; set; }
 
         /// <summary>
         /// Gets and sets list of Component's to search on.
@@ -443,9 +438,9 @@ namespace Microsoft.PowerShell.Commands
         private void GetAndWriteParameterInfo(HelpInfo helpInfo)
         {
             s_tracer.WriteLine("Searching parameters for {0}", helpInfo.Name);
-            List<PSObject> pInfosList = new List<PSObject>(_parameters.Length);
+            List<PSObject> pInfosList = new List<PSObject>(Parameter.Length);
 
-            foreach (var parameter in _parameters)
+            foreach (var parameter in Parameter)
             {
                 foreach (var pInfo in helpInfo.GetParameter(parameter))
                 {
@@ -491,7 +486,7 @@ namespace Microsoft.PowerShell.Commands
 
             if ((cat & supportedCategories) == 0)
             {
-                if (_parameters != null)
+                if (Parameter != null)
                 {
                     throw PSTraceSource.NewArgumentException("Parameter",
                         HelpErrors.ParamNotSupported, "-Parameter");
@@ -552,7 +547,7 @@ namespace Microsoft.PowerShell.Commands
                     // show inline help
                     if (showFullHelp)
                     {
-                        if (_parameters != null)
+                        if (Parameter != null)
                         {
                             GetAndWriteParameterInfo(helpInfo);
                         }
@@ -565,11 +560,11 @@ namespace Microsoft.PowerShell.Commands
                     }
                     else
                     {
-                        if (_parameters != null)
+                        if (Parameter != null)
                         {
-                            List<PSObject> pInfosList = new List<PSObject>(_parameters.Length);
+                            List<PSObject> pInfosList = new List<PSObject>(Parameter.Length);
 
-                            foreach (var parameter in _parameters)
+                            foreach (var parameter in Parameter)
                             {
                                 foreach (var pInfo in helpInfo.GetParameter(parameter))
                                 {

--- a/src/System.Management.Automation/help/HelpCommands.cs
+++ b/src/System.Management.Automation/help/HelpCommands.cs
@@ -157,7 +157,12 @@ namespace Microsoft.PowerShell.Commands
         /// Support WildCard strings as supported by WildcardPattern class.
         /// </remarks>
         [Parameter(ParameterSetName = "Parameters", Mandatory = true)]
-        public string Parameter { set; get; }
+        public string[] Parameter
+        {
+            get => _parameters;
+            set => _parameters = value;
+        }
+        private string[] _parameters;
 
         /// <summary>
         /// Gets and sets list of Component's to search on.
@@ -438,7 +443,17 @@ namespace Microsoft.PowerShell.Commands
         private void GetAndWriteParameterInfo(HelpInfo helpInfo)
         {
             s_tracer.WriteLine("Searching parameters for {0}", helpInfo.Name);
-            PSObject[] pInfos = helpInfo.GetParameter(Parameter);
+            List<PSObject> _pInfos = new List<PSObject>(_parameters.Length);
+
+            foreach (var _parameter in _parameters)
+            {
+                foreach (var _pInfo in helpInfo.GetParameter(_parameter))
+                {
+                    _pInfos.Add(_pInfo);
+                }
+            }
+
+            PSObject[] pInfos = _pInfos.ToArray();
 
             if ((pInfos == null) || (pInfos.Length == 0))
             {
@@ -476,7 +491,7 @@ namespace Microsoft.PowerShell.Commands
 
             if ((cat & supportedCategories) == 0)
             {
-                if (!string.IsNullOrEmpty(Parameter))
+                if (_parameters != null)
                 {
                     throw PSTraceSource.NewArgumentException("Parameter",
                         HelpErrors.ParamNotSupported, "-Parameter");
@@ -537,7 +552,7 @@ namespace Microsoft.PowerShell.Commands
                     // show inline help
                     if (showFullHelp)
                     {
-                        if (!string.IsNullOrEmpty(Parameter))
+                        if (_parameters != null)
                         {
                             GetAndWriteParameterInfo(helpInfo);
                         }
@@ -550,9 +565,20 @@ namespace Microsoft.PowerShell.Commands
                     }
                     else
                     {
-                        if (!string.IsNullOrEmpty(Parameter))
+                        if (_parameters != null)
                         {
-                            PSObject[] pInfos = helpInfo.GetParameter(Parameter);
+                            List<PSObject> _pInfos = new List<PSObject>(_parameters.Length);
+
+                            foreach (var _parameter in _parameters)
+                            {
+                                foreach (var _pInfo in helpInfo.GetParameter(_parameter))
+                                {
+                                    _pInfos.Add(_pInfo);
+                                }
+                            }
+
+                            PSObject[] pInfos = _pInfos.ToArray();
+
                             if ((pInfos == null) || (pInfos.Length == 0))
                             {
                                 return;

--- a/src/System.Management.Automation/help/HelpCommands.cs
+++ b/src/System.Management.Automation/help/HelpCommands.cs
@@ -443,17 +443,17 @@ namespace Microsoft.PowerShell.Commands
         private void GetAndWriteParameterInfo(HelpInfo helpInfo)
         {
             s_tracer.WriteLine("Searching parameters for {0}", helpInfo.Name);
-            List<PSObject> _pInfos = new List<PSObject>(_parameters.Length);
+            List<PSObject> pInfosList = new List<PSObject>(_parameters.Length);
 
-            foreach (var _parameter in _parameters)
+            foreach (var parameter in _parameters)
             {
-                foreach (var _pInfo in helpInfo.GetParameter(_parameter))
+                foreach (var pInfo in helpInfo.GetParameter(parameter))
                 {
-                    _pInfos.Add(_pInfo);
+                    pInfosList.Add(pInfo);
                 }
             }
 
-            PSObject[] pInfos = _pInfos.ToArray();
+            PSObject[] pInfos = pInfosList.ToArray();
 
             if ((pInfos == null) || (pInfos.Length == 0))
             {
@@ -567,17 +567,17 @@ namespace Microsoft.PowerShell.Commands
                     {
                         if (_parameters != null)
                         {
-                            List<PSObject> _pInfos = new List<PSObject>(_parameters.Length);
+                            List<PSObject> pInfosList = new List<PSObject>(_parameters.Length);
 
-                            foreach (var _parameter in _parameters)
+                            foreach (var parameter in _parameters)
                             {
-                                foreach (var _pInfo in helpInfo.GetParameter(_parameter))
+                                foreach (var pInfo in helpInfo.GetParameter(parameter))
                                 {
-                                    _pInfos.Add(_pInfo);
+                                    pInfosList.Add(pInfo);
                                 }
                             }
 
-                            PSObject[] pInfos = _pInfos.ToArray();
+                            PSObject[] pInfos = pInfosList.ToArray();
 
                             if ((pInfos == null) || (pInfos.Length == 0))
                             {


### PR DESCRIPTION
## PR Summary
Fix #8453 

This PR changes `Get-Help` cmdlet **-Parameter** parameter so it accepts string arrays.
Also changes `help` function.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
