### PR TITLE
Add support for PathSeparator property in Providers

### DIFF
--- a/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
+++ b/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
@@ -292,6 +292,7 @@ namespace System.Management.Automation
             PSSnapIn = providerInfo.PSSnapIn;
             _sessionState = providerInfo._sessionState;
             VolumeSeparatedByColon = providerInfo.VolumeSeparatedByColon;
+            PathSeparator = providerInfo.PathSeparator;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
+++ b/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
@@ -250,6 +250,14 @@ namespace System.Management.Automation
         /// non-windows platforms
         /// </summary>
         public bool VolumeSeparatedByColon { get; internal set; } = true;
+        
+        /// <summary>
+        /// Gets or sets the path separators characters for this provider
+        /// </summary>
+        /// <returns>
+        /// Array of strings representing the path separators for this provider
+        /// </returns>
+        public string[] PathSeparator { get; internal set; } = {};
 
         /// <summary>
         /// Constructs an instance of the class using an existing reference

--- a/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
+++ b/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
@@ -252,12 +252,12 @@ namespace System.Management.Automation
         public bool VolumeSeparatedByColon { get; internal set; } = true;
         
         /// <summary>
-        /// Gets or sets the path separators characters for this provider
+        /// Gets the path separators characters for this provider.
         /// </summary>
         /// <returns>
-        /// Array of strings representing the path separators for this provider
+        /// Array of strings representing the path separators characters for this provider.
         /// </returns>
-        public string[] PathSeparator { get; internal set; } = {};
+        public string[] PathSeparator { get; internal set; } = { };
 
         /// <summary>
         /// Constructs an instance of the class using an existing reference

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -343,7 +343,7 @@ namespace Microsoft.PowerShell.Commands
         #region CmdletProvider members
 
         /// <summary>
-        /// Starts the File System provider.  This method sets the Home for the
+        /// Starts the File System provider. This method sets the Home for the
         /// provider to providerInfo.Home if specified, and %USERPROFILE%
         /// otherwise.
         /// </summary>
@@ -356,20 +356,24 @@ namespace Microsoft.PowerShell.Commands
         protected override ProviderInfo Start(ProviderInfo providerInfo)
         {
             // Set the home folder for the user
-            if (providerInfo != null && string.IsNullOrEmpty(providerInfo.Home))
+            if (providerInfo != null)
             {
-                // %USERPROFILE% - indicate where a user's home directory is located in the file system.
-                string homeDirectory = Environment.GetEnvironmentVariable(Platform.CommonEnvVariableNames.Home);
+                providerInfo.PathSeparator = new [] { "\\" , "/" };
 
-                if (!string.IsNullOrEmpty(homeDirectory))
-                {
-                    if (Directory.Exists(homeDirectory))
+                if (string.IsNullOrEmpty(providerInfo.Home)) {
+                    // %USERPROFILE% - indicate where a user's home directory is located in the file system.
+                    string homeDirectory = Environment.GetEnvironmentVariable(Platform.CommonEnvVariableNames.Home);
+
+                    if (!string.IsNullOrEmpty(homeDirectory))
                     {
-                        s_tracer.WriteLine("Home = {0}", homeDirectory);
-                        providerInfo.Home = homeDirectory;
+                        if (Directory.Exists(homeDirectory))
+                        {
+                            s_tracer.WriteLine("Home = {0}", homeDirectory);
+                            providerInfo.Home = homeDirectory;
+                        }
+                        else
+                            s_tracer.WriteLine("Not setting home directory {0} - does not exist", homeDirectory);
                     }
-                    else
-                        s_tracer.WriteLine("Not setting home directory {0} - does not exist", homeDirectory);
                 }
             }
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -345,7 +345,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Starts the File System provider. This method sets the Home for the
         /// provider to providerInfo.Home if specified, and %USERPROFILE%
-        /// otherwise.
+        /// otherwise. It also sets the PathSeparator property.
         /// </summary>
         /// <param name="providerInfo">
         /// The ProviderInfo object that holds the provider's configuration.
@@ -358,9 +358,10 @@ namespace Microsoft.PowerShell.Commands
             // Set the home folder for the user
             if (providerInfo != null)
             {
-                providerInfo.PathSeparator = new [] { "\\" , "/" };
+                providerInfo.PathSeparator = new[] { "\\", "/" };
 
-                if (string.IsNullOrEmpty(providerInfo.Home)) {
+                if (string.IsNullOrEmpty(providerInfo.Home)) 
+                {
                     // %USERPROFILE% - indicate where a user's home directory is located in the file system.
                     string homeDirectory = Environment.GetEnvironmentVariable(Platform.CommonEnvVariableNames.Home);
 

--- a/src/System.Management.Automation/namespaces/FunctionProvider.cs
+++ b/src/System.Management.Automation/namespaces/FunctionProvider.cs
@@ -41,6 +41,29 @@ namespace Microsoft.PowerShell.Commands
 
         #endregion Constructor
 
+        #region CmdletProvider overrides
+
+        /// <summary>
+        /// Starts the Function provider. It sets the PathSeparator information
+        /// </summary>
+        /// <param name="providerInfo">
+        /// The ProviderInfo object that holds the provider's configuration.
+        /// </param>
+        /// <returns>
+        /// The updated ProviderInfo object that holds the provider's configuration.
+        /// </returns>
+        protected override ProviderInfo Start(ProviderInfo providerInfo)
+        {
+            if (providerInfo != null) 
+            {
+                providerInfo.PathSeparator = new [] { "\\", "/" };
+            }
+
+            return providerInfo;
+        }
+        
+        #endregion
+
         #region DriveCmdletProvider overrides
 
         /// <summary>

--- a/src/System.Management.Automation/namespaces/FunctionProvider.cs
+++ b/src/System.Management.Automation/namespaces/FunctionProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PowerShell.Commands
         #region CmdletProvider overrides
 
         /// <summary>
-        /// Starts the Function provider. It sets the PathSeparator information
+        /// Starts the Function provider. It sets the PathSeparator property.
         /// </summary>
         /// <param name="providerInfo">
         /// The ProviderInfo object that holds the provider's configuration.
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.Commands
         {
             if (providerInfo != null) 
             {
-                providerInfo.PathSeparator = new [] { "\\", "/" };
+                providerInfo.PathSeparator = new[] { "\\", "/" };
             }
 
             return providerInfo;

--- a/src/System.Management.Automation/namespaces/RegistryProvider.cs
+++ b/src/System.Management.Automation/namespaces/RegistryProvider.cs
@@ -89,7 +89,7 @@ namespace Microsoft.PowerShell.Commands
         #region CmdletProvider overrides
 
         /// <summary>
-        /// Starts the Registry provider. It sets the PathSeparator information
+        /// Starts the Registry provider. It sets the PathSeparator property.
         /// </summary>
         /// <param name="providerInfo">
         /// The ProviderInfo object that holds the provider's configuration.
@@ -101,7 +101,7 @@ namespace Microsoft.PowerShell.Commands
         {
             if (providerInfo != null) 
             {
-                providerInfo.PathSeparator = new [] { "\\" };
+                providerInfo.PathSeparator = new[] { "\\" };
             }
 
             return providerInfo;

--- a/src/System.Management.Automation/namespaces/RegistryProvider.cs
+++ b/src/System.Management.Automation/namespaces/RegistryProvider.cs
@@ -86,6 +86,29 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         public const string ProviderName = "Registry";
 
+        #region CmdletProvider overrides
+
+        /// <summary>
+        /// Starts the Registry provider. It sets the PathSeparator information
+        /// </summary>
+        /// <param name="providerInfo">
+        /// The ProviderInfo object that holds the provider's configuration.
+        /// </param>
+        /// <returns>
+        /// The updated ProviderInfo object that holds the provider's configuration.
+        /// </returns>
+        protected override ProviderInfo Start(ProviderInfo providerInfo)
+        {
+            if (providerInfo != null) 
+            {
+                providerInfo.PathSeparator = new [] { "\\" };
+            }
+
+            return providerInfo;
+        }
+
+        #endregion
+
         #region DriveCmdletProvider overrides
 
         /// <summary>

--- a/src/System.Management.Automation/namespaces/VariableProvider.cs
+++ b/src/System.Management.Automation/namespaces/VariableProvider.cs
@@ -40,6 +40,29 @@ namespace Microsoft.PowerShell.Commands
 
         #endregion Constructor
 
+        #region CmdletProvider overrides
+
+        /// <summary>
+        /// Starts the Variable provider. It sets the PathSeparator information
+        /// </summary>
+        /// <param name="providerInfo">
+        /// The ProviderInfo object that holds the provider's configuration.
+        /// </param>
+        /// <returns>
+        /// The updated ProviderInfo object that holds the provider's configuration.
+        /// </returns>
+        protected override ProviderInfo Start(ProviderInfo providerInfo)
+        {
+            if (providerInfo != null) 
+            {
+                providerInfo.PathSeparator = new [] { "\\", "/" };
+            }
+
+            return providerInfo;
+        }
+        
+        #endregion
+
         #region DriveCmdletProvider overrides
 
         /// <summary>

--- a/src/System.Management.Automation/namespaces/VariableProvider.cs
+++ b/src/System.Management.Automation/namespaces/VariableProvider.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerShell.Commands
         #region CmdletProvider overrides
 
         /// <summary>
-        /// Starts the Variable provider. It sets the PathSeparator information
+        /// Starts the Variable provider. It sets the PathSeparator property.
         /// </summary>
         /// <param name="providerInfo">
         /// The ProviderInfo object that holds the provider's configuration.
@@ -55,7 +55,7 @@ namespace Microsoft.PowerShell.Commands
         {
             if (providerInfo != null) 
             {
-                providerInfo.PathSeparator = new [] { "\\", "/" };
+                providerInfo.PathSeparator = new[] { "\\", "/" };
             }
 
             return providerInfo;

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-PSProvider.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-PSProvider.Tests.ps1
@@ -33,7 +33,9 @@ Describe "Get-PSProvider" -Tags "CI" {
 
     Context 'Registry provider' {
         It 'has PathSeparator property' {
-            (Get-PSProvider Registry).PathSeparator | Should -Be @("\")
+            if ($IsWindows) {
+                (Get-PSProvider Registry).PathSeparator | Should -Be @("\")
+            }
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-PSProvider.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-PSProvider.Tests.ps1
@@ -24,4 +24,28 @@ Describe "Get-PSProvider" -Tags "CI" {
 
 	{ $actual | Format-List } | Should -Not -Throw
     }
+
+    Context 'FileSystem provider' {
+        It 'has PathSeparator property' {
+            (Get-PSProvider FileSystem).PathSeparator | Should -Be @("\", "/")
+        }
+    }
+
+    Context 'Registry provider' {
+        It 'has PathSeparator property' {
+            (Get-PSProvider Registry).PathSeparator | Should -Be @("\")
+        }
+    }
+
+    Context 'Variable provider' {
+        It 'has PathSeparator property' {
+            (Get-PSProvider Variable).PathSeparator | Should -Be @("\", "/")
+        }
+    }
+
+    Context 'Function provider' {
+        It 'has PathSeparator property' {
+            (Get-PSProvider Function).PathSeparator | Should -Be @("\", "/")
+        }
+    }
 }


### PR DESCRIPTION
## PR Summary

Fix #5544.

Add `PathSeparator` property in `ProviderInfo` class.

Set corresponding values for `PathSeparator` according to each `Provider` class

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
